### PR TITLE
Fix environment.yaml

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -1,4 +1,4 @@
-name: LRO
+name: KRO
 channels:
   - conda-forge
 dependencies:

--- a/test_connection
+++ b/test_connection
@@ -12,4 +12,4 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 cd $DIR
 
 #launch
-python lick_vnc_launcher.py --test shane
+python3 lick_vnc_launcher.py --test shane


### PR DESCRIPTION
environment.yaml establishes a conda environment named LRO but the rest of the codebase references the KRO environment. This change makes the conda environment consistent so that the set-up process goes smoothly